### PR TITLE
fix: 配置faiss消岐方法时, 只设置全局消岐的提示词就可以

### DIFF
--- a/ui/src/views/knowledge/KagIntegration.vue
+++ b/ui/src/views/knowledge/KagIntegration.vue
@@ -163,16 +163,6 @@
                         </el-form-item>
                       </el-col>
                     </el-row>
-                      <el-form-item label="FAISS Prompt">
-                        <el-select 
-                            v-model="form.kag_pipeline_config.disambiguation_config.faiss_prompt" 
-                            :placeholder="$t('views.knowledge.kag.form.promptIdPlaceholder')" 
-                            clearable 
-                            class="w-full"
-                        >
-                          <el-option v-for="item in disambiguationPromptOptions" :key="item.id" :label="item.name" :value="item.id" />
-                        </el-select>
-                      </el-form-item>
                   </div>
 
                    <el-divider content-position="left">Common</el-divider>
@@ -589,6 +579,11 @@ async function saveConfig() {
   // Clean nested configs
   const pipeline = payload.kag_pipeline_config
   if (pipeline) {
+      // Sync faiss_prompt with prompt_id for disambiguation
+      if (pipeline.disambiguation_config) {
+        pipeline.disambiguation_config.faiss_prompt = pipeline.disambiguation_config.prompt_id
+      }
+
       ['extraction_config', 'disambiguation_config', 'relation_extraction_config', 'triple_refinement_config', 'predicate_refinement_config', 'graph_db_config'].forEach(key => {
           if (pipeline[key]) {
               pipeline[key].llm_config_id = cleanId(pipeline[key].llm_config_id)
@@ -621,6 +616,11 @@ async function handleExport() {
   
   const pipeline = payload.kag_pipeline_config
    if (pipeline) {
+      // Sync faiss_prompt with prompt_id for disambiguation
+      if (pipeline.disambiguation_config) {
+        pipeline.disambiguation_config.faiss_prompt = pipeline.disambiguation_config.prompt_id
+      }
+
       ['extraction_config', 'disambiguation_config', 'relation_extraction_config', 'triple_refinement_config', 'predicate_refinement_config', 'graph_db_config'].forEach(key => {
           if (pipeline[key]) {
               pipeline[key].llm_config_id = cleanId(pipeline[key].llm_config_id)


### PR DESCRIPTION
## 🔗 关联 Issue (Related Issue)
Closes #8 

## 📝 变更类型 (Type of Change)
- [ ] ✨ 新功能 (New feature)
- [*] 🐛 Bug 修复 (Bug fix)
- [ ] 📚 文档修改 (Documentation update)
- [ ] 💎 代码重构 (Refactoring)
- [ ] 🚀 性能优化 (Performance improvement)
- [ ] ✅ 测试用例 (Test cases)
- [ ] 🔧 其他 (Chore/Style/CI)

## 💡 背景与详细描述 (Background & Solution)
**问题描述**：
消歧kag里已经合并成一个提示词了，maxkb这边如果只选一个会报错
**解决方案**：
配置faiss消岐方法时, 只设置全局消岐的提示词
## 📸 截图或测试日志 (Screenshots / Logs)
## ✅ 检查清单 (Self-Check List)
- [ ] 我已阅读并遵守 [CONTRIBUTING.md](../CONTRIBUTING.md) 指引
- [ ] 我的 Commit Message 遵循 Conventional Commits 规范 (如 `feat: xxx`)
- [ ] 我对自己提交的代码进行了自我审查 (Self-review)
- [ ] 关键逻辑已添加必要的注释
- [ ] (如有必要) 我已更新了对应的文档 (包括 `DEV_MANUAL.md`)
- [ ] 本地运行测试未发现新的报错

---
感谢你的贡献！❤️